### PR TITLE
Do not create report file if nothing to report

### DIFF
--- a/src/Codeception/Extension/AxeCeptionReporter.php
+++ b/src/Codeception/Extension/AxeCeptionReporter.php
@@ -90,6 +90,10 @@ class AxeCeptionReporter extends Extension
         $testsVm = [];
         $testIndex = 0;
 
+        if ($this->axeResults === []) {
+            return;
+        }
+
         foreach ($this->axeResults as $axeResult) {
             $test = $axeResult['test'];
             /** @var AxeStep[] $axeSteps */


### PR DESCRIPTION
Summary:
Add early return check to skip report generation
when there are no axe results to report.